### PR TITLE
Add API deployment support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ python project/main.py
 
 Enter your travel request when prompted; the tool will print a structured representation.
 
+## Running as a web service
+Install the extra dependencies and start the FastAPI server:
+```bash
+uvicorn api:app --host 0.0.0.0 --port 8000
+```
+Send POST requests to `/parse` with plain text and the service will return a `TravelRequest` JSON.
+
+To containerize the application:
+```bash
+docker build -t travel-parser .
+docker run -p 8000:8000 travel-parser
+```
+
 ## Project Structure
 ```
 project/
@@ -45,3 +58,13 @@ project/
 - Format/validate code with `python -m compileall -q project`.
 - Tests can be added under a `tests/` folder in the future.
 - Contributions and issues are welcome; please open a PR.
+
+## Publishing
+To make the repository available online, initialize Git and push to a remote:
+```bash
+git init
+git add .
+git commit -m "Initial commit"
+git remote add origin <your-remote-url>
+git push -u origin main
+```

--- a/api.py
+++ b/api.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI, HTTPException
+from project.utils.parser import parse_natural_input_to_travel_request
+from project.models import TravelRequest
+
+app = FastAPI()
+
+
+@app.post("/parse", response_model=TravelRequest)
+def parse(text: str):
+    try:
+        return parse_natural_input_to_travel_request(text)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 openai>=1.11
 pydantic>=2.7
 python-dotenv>=1.0
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- expose FastAPI web API with `api.py`
- add Dockerfile to containerize the app
- update README with web service and publishing instructions
- include FastAPI and Uvicorn in requirements

## Testing
- `python -m compileall -q project api.py`

------
https://chatgpt.com/codex/tasks/task_e_685c1da2d9c4832bae6f6b0e297b495e